### PR TITLE
Handle non notebook based runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Released on TBD
 
 ### Added
 
-- Logging of job runs tasks status within `jobs_runs_submit_and_wait_for_completion` - [#16](https://github.com/PrefectHQ/prefect-databricks/pull/16
+- Logging of job runs tasks status within `jobs_runs_submit_and_wait_for_completion` - [#16](https://github.com/PrefectHQ/prefect-databricks/pull/16).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## 0.1.2
+
+Released on TBD
+
+### Edited
+
+- `jobs_runs_submit_and_wait_for_completion` flow - [#16](https://github.com/PrefectHQ/prefect-databricks/pull/16)
+
+
 ## 0.1.1
 
 Released on August 19th, 2022.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Released on TBD
 
 ### Fixed
 
-- Executing Python scripts through `jobs_runs_submit_and_wait_for_completion` - [#16](https://github.com/PrefectHQ/prefect-databricks/pull/16)
+- Executing Python scripts through `jobs_runs_submit_and_wait_for_completion` - [#16](https://github.com/PrefectHQ/prefect-databricks/pull/16).
 
 
 ## 0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,11 @@ Released on TBD
 
 ### Added
 
-- Logging of job runs tasks status within `jobs_runs_submit_and_wait_for_completion` - [#16](https://github.com/PrefectHQ/prefect-databricks/pull/16)
+- Logging of job runs tasks status within `jobs_runs_submit_and_wait_for_completion` - [#16](https://github.com/PrefectHQ/prefect-databricks/pull/16
+
+### Fixed
+
+- Executing Python scripts through `jobs_runs_submit_and_wait_for_completion` - [#16](https://github.com/PrefectHQ/prefect-databricks/pull/16)
 
 
 ## 0.1.1

--- a/prefect_databricks/flows.py
+++ b/prefect_databricks/flows.py
@@ -356,7 +356,7 @@ def __log_state(
     state: Dict[str, Any],
     run_page_url: str,
     logger: Logger,
-    is_task: bool = True,
+    run_type: Literal["Task", "Job"] = "Task",
 ):
     """
     Stores the states of a job or task to its collection and logs the output

--- a/prefect_databricks/flows.py
+++ b/prefect_databricks/flows.py
@@ -351,7 +351,7 @@ async def jobs_runs_submit_and_wait_for_completion(
 
 def log_state(array: Dict, run_id, state: Dict, run_page_url, logger, is_task=True):
     """
-    Adds the new state of a job or task to its collection and logs the output
+    Stores the states of a job or task to its collection and logs the output
     if it changes
 
     Args:

--- a/prefect_databricks/flows.py
+++ b/prefect_databricks/flows.py
@@ -355,12 +355,12 @@ def log_state(array: Dict, run_id, state: Dict, run_page_url, logger, is_task=Tr
     if it changes
 
     Args:
-        array: The array of the Job or Task collection
-        run_id: Id of the run in databricks for the Job or Task
-        state: State object of the run in databricks for the Job or Task
-        run_page_url: Url of the run in databricks for the Job or Task in
-            the databricks UI
-        logger: logger instance to log with
+        array: The array of the Job or Task collection.
+        run_id: Id of the run in Databricks for the Job or Task.
+        state: State object of the run in Databricks for the Job or Task.
+        run_page_url: URL of the run in Databricks for the Job or Task in
+            the Databricks UI.
+        logger: Logger instance to log with.
         is_task: Bool indicating if is Job or Task
 
     Returns:

--- a/prefect_databricks/flows.py
+++ b/prefect_databricks/flows.py
@@ -355,13 +355,13 @@ def log_state(array: Dict, run_id, state: Dict, run_page_url, logger, is_task=Tr
     if it changes
 
     Args:
-        array: The array of the Job or Task collection.
-        run_id: Id of the run in Databricks for the Job or Task.
-        state: State object of the run in Databricks for the Job or Task.
-        run_page_url: URL of the run in Databricks for the Job or Task in
+        array: The array of the job or task collection.
+        run_id: Id of the run in Databricks for the job or task.
+        state: State object of the run in Databricks for the job or task.
+        run_page_url: URL of the run in Databricks for the job or task in
             the Databricks UI.
         logger: Logger instance to log with.
-        is_task: Bool indicating if is Job or Task
+        is_task: Bool indicating if is job or task
 
     """
 

--- a/prefect_databricks/flows.py
+++ b/prefect_databricks/flows.py
@@ -352,7 +352,7 @@ async def jobs_runs_submit_and_wait_for_completion(
 def log_state(array: Dict, run_id, state: Dict, run_page_url, logger, is_task=True):
     """
     Adds the new state of a job or task to its collection and logs the output
-     if it changes
+    if it changes
 
     Args:
         array: The array of the Job or Task collection

--- a/prefect_databricks/flows.py
+++ b/prefect_databricks/flows.py
@@ -3,6 +3,7 @@ Module containing flows for interacting with Databricks
 """
 
 import asyncio
+from logging import Logger
 from typing import Any, Dict, List
 
 from prefect import flow, get_run_logger
@@ -270,7 +271,7 @@ async def jobs_runs_submit_and_wait_for_completion(
         jobs_runs_run_page_url = jobs_runs_metadata.get("run_page_url", "")
         jobs_runs_state = jobs_runs_metadata["state"]
 
-        log_state(
+        __log_state(
             job_status_info,
             jobs_runs_run_id,
             jobs_runs_state,
@@ -286,7 +287,7 @@ async def jobs_runs_submit_and_wait_for_completion(
             task_run_page_url = runs_task.get("run_page_url", "")
             task_runs_state = runs_task.get("state", {})
 
-            log_state(
+            __log_state(
                 task_status_info,
                 task_run_id,
                 task_runs_state,
@@ -349,7 +350,14 @@ async def jobs_runs_submit_and_wait_for_completion(
     )
 
 
-def log_state(array: Dict, run_id, state: Dict, run_page_url, logger, is_task=True):
+def __log_state(
+    array: Dict[str, Any],
+    run_id: str,
+    state: Dict[str, Any],
+    run_page_url: str,
+    logger: Logger,
+    is_task: bool = True,
+):
     """
     Stores the states of a job or task to its collection and logs the output
     if it changes

--- a/prefect_databricks/flows.py
+++ b/prefect_databricks/flows.py
@@ -363,9 +363,6 @@ def log_state(array: Dict, run_id, state: Dict, run_page_url, logger, is_task=Tr
         logger: Logger instance to log with.
         is_task: Bool indicating if is Job or Task
 
-    Returns:
-        void
-
     """
 
     string_run_id = str(run_id)

--- a/prefect_databricks/rest.py
+++ b/prefect_databricks/rest.py
@@ -18,6 +18,10 @@ if TYPE_CHECKING:
 
 
 class HTTPMethod(Enum):
+    """
+    Enum for HTTP Verbs
+    """
+
     GET = "get"
     POST = "post"
     PUT = "put"

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -1,6 +1,4 @@
-import logging
 import re
-import unittest
 
 import pytest
 from httpx import Response
@@ -13,7 +11,6 @@ from prefect_databricks.flows import (
     DatabricksJobSkipped,
     DatabricksJobTerminated,
     jobs_runs_submit_and_wait_for_completion,
-    log_state,
 )
 
 
@@ -112,12 +109,6 @@ def successful_job_path(request, route):
 
 
 class TestJobsRunsSubmitAndWaitForCompletion:
-    async def test_log_entered_when_mismatched_state(self):
-        logger = logging.getLogger("prefect")
-        with unittest.mock.patch.object(logger, "info") as mock_log:
-            log_state({}, "1234", {}, "", mock_log)
-            assert mock_log.info.call_count == 1
-
     @pytest.mark.respx(assert_all_called=True)
     async def test_run_success(self, common_mocks, respx_mock, databricks_credentials):
         respx_mock.get(

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -40,21 +40,29 @@ def test_strip_kwargs():
     assert strip_kwargs(**dict(a=[])) == {"a": []}
 
 
-class TestAnotherBaseModel(BaseModel):
+class AnotherBaseModel(BaseModel):
 
     some_float: float
     some_bool: bool
 
 
-class TestBaseModel(BaseModel):
+class BaseModel(BaseModel):
     class Config:
         extra = Extra.allow
         allow_mutation = False
 
     some_string: str
     some_int: int
-    another_base_model: TestAnotherBaseModel
-    other_base_models: List[TestAnotherBaseModel]
+    another_base_model: AnotherBaseModel
+    other_base_models: List[AnotherBaseModel]
+
+
+def test_http_matches_type():
+    assert HTTPMethod.DELETE.value == "delete"
+    assert HTTPMethod.GET.value == "get"
+    assert HTTPMethod.PATCH.value == "patch"
+    assert HTTPMethod.POST.value == "post"
+    assert HTTPMethod.PUT.value == "put"
 
 
 def test_serialize_model():
@@ -73,14 +81,14 @@ def test_serialize_model():
 
     actual = serialize_model(
         {
-            "base_model": TestBaseModel(
+            "base_model": BaseModel(
                 some_string="abc",
                 some_int=1,
                 unexpected_value=["super", "unexpected"],
-                another_base_model=TestAnotherBaseModel(some_float=2.8, some_bool=True),
+                another_base_model=AnotherBaseModel(some_float=2.8, some_bool=True),
                 other_base_models=[
-                    TestAnotherBaseModel(some_float=8.8, some_bool=False),
-                    TestAnotherBaseModel(some_float=1.8, some_bool=True),
+                    AnotherBaseModel(some_float=8.8, some_bool=False),
+                    AnotherBaseModel(some_float=1.8, some_bool=True),
                 ],
             )
         }

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -81,7 +81,7 @@ def test_serialize_model():
 
     actual = serialize_model(
         {
-            "base_model": BaseModel(
+            "base_model": ExampleBaseModel(
                 some_string="abc",
                 some_int=1,
                 unexpected_value=["super", "unexpected"],

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -46,7 +46,7 @@ class AnotherBaseModel(BaseModel):
     some_bool: bool
 
 
-class BaseModel(BaseModel):
+class ExampleBaseModel(BaseModel):
     class Config:
         extra = Extra.allow
         allow_mutation = False


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-databricks! 🎉-->

## Summary
When a non-notebook based task is ran on the *jobs_runs_submit_and_wait_for_completion* method, the code expects a *notebook_output* key to exist on the response Dict. Unfortunately when submitting a python file to execute and not a notebook, the *notebook_output* field is null. 

I have aldo added the run_page_url to the logs for ease of reference to the run and tak runs associated to the processing.

## Relevant Issue(s)
n/a

## Checklist
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-databricks/blob/main/CHANGELOG.md)
