### PR TITLE
Refactor for better display in radar ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+- `jobs_runs_wait_for_completion` flow - [#22](https://github.com/PrefectHQ/prefect-databricks/pull/22).
 
 ### Changed
+
+- Migrate lines from `jobs_runs_submit_and_wait_for_completion` into `jobs_runs_wait_for_completion` flow - [#22](https://github.com/PrefectHQ/prefect-databricks/pull/22).
 
 ### Deprecated
 

--- a/prefect_databricks/flows.py
+++ b/prefect_databricks/flows.py
@@ -205,7 +205,7 @@ async def jobs_runs_submit_and_wait_for_completion(
         )
 
         @flow
-        async def jobs_runs_submit_and_wait_for_completion_flow(notebook_path, **base_parameters):
+        def jobs_runs_submit_and_wait_for_completion_flow(notebook_path, **base_parameters):
             databricks_credentials = await DatabricksCredentials.load("BLOCK_NAME")
 
             # specify new cluster settings
@@ -238,7 +238,7 @@ async def jobs_runs_submit_and_wait_for_completion(
                 task_key="prefect-task"
             )
 
-            multi_task_runs = await jobs_runs_submit_and_wait_for_completion(
+            multi_task_runs = jobs_runs_submit_and_wait_for_completion(
                 databricks_credentials=databricks_credentials,
                 run_name="prefect-job",
                 tasks=[job_task_settings]
@@ -400,6 +400,42 @@ async def jobs_runs_wait_for_completion(
     max_wait_seconds: int = 900,
     poll_frequency_seconds: int = 10,
 ):
+    """
+    Flow that triggers a job run and waits for the triggered run to complete.
+
+    Args:
+        run_name: The name of the jobs runs task.
+        multi_task_jobs_run_id: The ID of the jobs runs task to watch.
+        databricks_credentials:
+            Credentials to use for authentication with Databricks.
+        max_wait_seconds:
+            Maximum number of seconds to wait for the entire flow to complete.
+        poll_frequency_seconds: Number of seconds to wait in between checks for
+            run completion.
+
+    Returns:
+        jobs_runs_state: A dict containing the jobs runs life cycle state and message.
+        jobs_runs_metadata: A dict containing IDs of the jobs runs tasks.
+
+    Example:
+        Waits for completion on jobs runs.
+        ```python
+        from prefect import flow
+        from prefect_databricks import DatabricksCredentials
+        from prefect_databricks.flows import jobs_runs_wait_for_completion
+
+        @flow
+        def jobs_runs_wait_for_completion_flow():
+            databricks_credentials = DatabricksCredentials.load("BLOCK_NAME")
+            return jobs_runs_wait_for_completion(
+                run_name="my_run_name",
+                multi_task_jobs_run_id=45429,
+                databricks_credentials=databricks_credentials,
+                max_wait_seconds=1800,  # 30 minutes
+                poll_frequency_seconds=120,  # 2 minutes
+            )
+        ```
+    """
     logger = get_run_logger()
 
     seconds_waited_for_run_completion = 0


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-databricks! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->
Refactors `jobs_runs_wait_for_completion` for better display in radar UI. This is accomplished by moving all tasks that check for run status into a subflow for grouping in radar.
![image](https://user-images.githubusercontent.com/15331990/189966789-75446264-0e7f-461b-9b91-fdb19da7c888.png)

![image](https://user-images.githubusercontent.com/15331990/189966648-58b598df-d7bf-4d57-9d6c-e6ef1c3f1186.png)

Also tweaks logging so it's easier to read the statuses.
```
10:18:53.706 | INFO    | Flow run 'quixotic-ringtail' - Job Run '45429' states updated!
Life cycle: 'TERMINATED'
Result: 'SUCCESS'
Message ''
Url: https://dbc-.cloud.databricks.com/?o=2707332449367147#job/615148572428188/run/45429

10:18:53.706 | INFO    | Flow run 'quixotic-ringtail' - Task Run '45682' states updated!
Life cycle: 'TERMINATED'
Result: 'SUCCESS'
Message ''
Url: https://dbc-.cloud.databricks.com/?o=2707332449367147#job/615148572428188/run/45682
```

## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->
Closes #19 

## Checklist
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-databricks/blob/main/CHANGELOG.md)
