### PR TITLE
Run job by id

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# prefect-databricks
+
+## Welcome!
+
+Prefect integrations interacting with Databricks
+
+The tasks within this collection were created by a code generator using the service's OpenAPI spec.
+
+The service's REST API documentation can be found [here](https://docs.databricks.com/dev-tools/api/latest/index.html).
 # Integrate Databricks jobs into your dataflow with prefect-databricks
  
 <p align="center">
@@ -105,6 +114,29 @@ jobs_runs_submit_flow(
     notebook_path="/Users/<EMAIL_ADDRESS_PLACEHOLDER>/example.ipynb",
     name="Marvin"
 )
+```
+
+Another example in which you do have an existing Databricks job and wish to trigger it by inputting the job id is below.
+```python
+from prefect import flow
+
+from prefect_databricks import DatabricksCredentials
+from prefect_databricks.flows import (
+    jobs_runs_submit_by_id_and_wait_for_completion,
+)
+
+
+@flow
+def existing_job_submit(block_name: str, job_id):
+    databricks_credentials = DatabricksCredentials.load(block_name)
+
+    run = jobs_runs_submit_by_id_and_wait_for_completion(
+        databricks_credentials=databricks_credentials, job_id=job_id
+    )
+
+    return run
+
+existing_job_submit(block_name="db-creds", job_id="YOUR-JOB-NAME")
 ```
 
 Upon execution, the notebook run should output:

--- a/README.md
+++ b/README.md
@@ -116,7 +116,28 @@ jobs_runs_submit_flow(
 )
 ```
 
+Upon execution, the notebook run should output:
+
+```
+Don't worry Marvin, I got your request! Welcome to prefect-databricks!
+```
+
+!!! info "Input dictionaries in the place of models"
+    
+    Instead of using the built-in models, you may also input a valid dictionary.
+    
+    For example, the following are equivalent:
+
+    ```python
+    auto_scale=AutoScale(min_workers=1, max_workers=2)
+    ```
+
+    ```python
+    auto_scale={"min_workers": 1, "max_workers": 2}
+    ```
+
 Another example in which you do have an existing Databricks job and wish to trigger it by inputting the job id is below.
+
 ```python
 from prefect import flow
 
@@ -138,26 +159,6 @@ def existing_job_submit(block_name: str, job_id):
 
 existing_job_submit(block_name="db-creds", job_id="YOUR-JOB-NAME")
 ```
-
-Upon execution, the notebook run should output:
-
-```
-Don't worry Marvin, I got your request! Welcome to prefect-databricks!
-```
-
-!!! info "Input dictionaries in the place of models"
-    
-    Instead of using the built-in models, you may also input a valid dictionary.
-    
-    For example, the following are equivalent:
-
-    ```python
-    auto_scale=AutoScale(min_workers=1, max_workers=2)
-    ```
-
-    ```python
-    auto_scale={"min_workers": 1, "max_workers": 2}
-    ```
 
 ## Resources
 

--- a/prefect_databricks/flows.py
+++ b/prefect_databricks/flows.py
@@ -185,16 +185,17 @@ async def jobs_runs_submit_by_id_and_wait_for_completion(
     )
 
     jobs_runs = await jobs_runs_future.result()
-    # jobs_runs_id = jobs_runs["run_id"]
+    jobs_runs_id = jobs_runs["run_id"]
 
     # wait for all the jobs runs to complete in a separate flow
     # for a cleaner radar interface
     jobs_runs_state, jobs_runs_metadata = await jobs_runs_wait_for_completion(
-        multi_task_jobs_runs_id=job_id,
+        multi_task_jobs_runs_id=jobs_runs_id,
         databricks_credentials=databricks_credentials,
         max_wait_seconds=max_wait_seconds,
         poll_frequency_seconds=poll_frequency_seconds,
     )
+    print(jobs_runs_metadata)
 
     # fetch the state results
     jobs_runs_life_cycle_state = jobs_runs_state["life_cycle_state"]
@@ -205,16 +206,17 @@ async def jobs_runs_submit_by_id_and_wait_for_completion(
         jobs_runs_result_state = jobs_runs_state.get("result_state", None)
         if jobs_runs_result_state == RunResultState.success.value:
             task_notebook_outputs = {}
-            for task in jobs_runs_metadata["tasks"]:
-                task_key = task["task_key"]
-                task_run_id = task["run_id"]
-                task_run_output_future = await jobs_runs_get_output.submit(
-                    run_id=task_run_id,
-                    databricks_credentials=databricks_credentials,
-                )
-                task_run_output = await task_run_output_future.result()
-                task_run_notebook_output = task_run_output.get("notebook_output", {})
-                task_notebook_outputs[task_key] = task_run_notebook_output
+            # for task in jobs_runs_metadata["tasks"]:
+            # task_key = task["task_key"]
+            task_run_id = jobs_runs_metadata["run_id"]
+            task_run_output_future = await jobs_runs_get_output.submit(
+                run_id=task_run_id,
+                databricks_credentials=databricks_credentials,
+            )
+            task_run_output = await task_run_output_future.result()
+            task_run_notebook_output = task_run_output.get("notebook_output", {})
+            print(task_run_notebook_output)
+            # task_notebook_outputs[task_key] = task_run_notebook_output
             logger.info(
                 "Databricks Jobs Runs Submit (%s ID %s) completed successfully!",
                 job_id,

--- a/prefect_databricks/flows.py
+++ b/prefect_databricks/flows.py
@@ -627,7 +627,7 @@ async def jobs_runs_wait_for_completion(
 
         jobs_runs_metadata = await jobs_runs_metadata_future.result()
         jobs_status = _update_and_log_state_changes(
-            jobs_status, jobs_runs_metadata, logger, b"Job"
+            jobs_status, jobs_runs_metadata, logger, "Job"
         )
         jobs_runs_metadata_tasks = jobs_runs_metadata.get("tasks", [])
         for task_metadata in jobs_runs_metadata_tasks:

--- a/prefect_databricks/flows.py
+++ b/prefect_databricks/flows.py
@@ -13,6 +13,7 @@ from prefect_databricks.jobs import (
     jobs_runs_get,
     jobs_runs_get_output,
     jobs_runs_submit,
+    jobs_run_now,
 )
 from prefect_databricks.models.jobs import (
     AccessControlRequest,
@@ -68,179 +69,7 @@ async def jobs_runs_submit_and_wait_for_completion(
     access_control_list: Optional[List[AccessControlRequest]] = None,
     **jobs_runs_submit_kwargs: Dict[str, Any],
 ) -> Dict:
-    """
-    Flow that triggers a job run and waits for the triggered run to complete.
 
-    Args:
-        databricks_credentials:
-            Credentials to use for authentication with Databricks.
-        tasks: Tasks to run, e.g.
-            ```
-            [
-                {
-                    "task_key": "Sessionize",
-                    "description": "Extracts session data from events",
-                    "depends_on": [],
-                    "existing_cluster_id": "0923-164208-meows279",
-                    "spark_jar_task": {
-                        "main_class_name": "com.databricks.Sessionize",
-                        "parameters": ["--data", "dbfs:/path/to/data.json"],
-                    },
-                    "libraries": [{"jar": "dbfs:/mnt/databricks/Sessionize.jar"}],
-                    "timeout_seconds": 86400,
-                },
-                {
-                    "task_key": "Orders_Ingest",
-                    "description": "Ingests order data",
-                    "depends_on": [],
-                    "existing_cluster_id": "0923-164208-meows279",
-                    "spark_jar_task": {
-                        "main_class_name": "com.databricks.OrdersIngest",
-                        "parameters": ["--data", "dbfs:/path/to/order-data.json"],
-                    },
-                    "libraries": [{"jar": "dbfs:/mnt/databricks/OrderIngest.jar"}],
-                    "timeout_seconds": 86400,
-                },
-                {
-                    "task_key": "Match",
-                    "description": "Matches orders with user sessions",
-                    "depends_on": [
-                        {"task_key": "Orders_Ingest"},
-                        {"task_key": "Sessionize"},
-                    ],
-                    "new_cluster": {
-                        "spark_version": "7.3.x-scala2.12",
-                        "node_type_id": "i3.xlarge",
-                        "spark_conf": {"spark.speculation": True},
-                        "aws_attributes": {
-                            "availability": "SPOT",
-                            "zone_id": "us-west-2a",
-                        },
-                        "autoscale": {"min_workers": 2, "max_workers": 16},
-                    },
-                    "notebook_task": {
-                        "notebook_path": "/Users/user.name@databricks.com/Match",
-                        "base_parameters": {"name": "John Doe", "age": "35"},
-                    },
-                    "timeout_seconds": 86400,
-                },
-            ]
-            ```
-        run_name:
-            An optional name for the run. The default value is `Untitled`, e.g. `A
-            multitask job run`.
-        git_source:
-            This functionality is in Public Preview.  An optional specification for
-            a remote repository containing the notebooks used by this
-            job's notebook tasks. Key-values:
-            - git_url:
-                URL of the repository to be cloned by this job. The maximum
-                length is 300 characters, e.g.
-                `https://github.com/databricks/databricks-cli`.
-            - git_provider:
-                Unique identifier of the service used to host the Git
-                repository. The value is case insensitive, e.g. `github`.
-            - git_branch:
-                Name of the branch to be checked out and used by this job.
-                This field cannot be specified in conjunction with git_tag
-                or git_commit. The maximum length is 255 characters, e.g.
-                `main`.
-            - git_tag:
-                Name of the tag to be checked out and used by this job. This
-                field cannot be specified in conjunction with git_branch or
-                git_commit. The maximum length is 255 characters, e.g.
-                `release-1.0.0`.
-            - git_commit:
-                Commit to be checked out and used by this job. This field
-                cannot be specified in conjunction with git_branch or
-                git_tag. The maximum length is 64 characters, e.g.
-                `e0056d01`.
-            - git_snapshot:
-                Read-only state of the remote repository at the time the job was run.
-                            This field is only included on job runs.
-        timeout_seconds:
-            An optional timeout applied to each run of this job. The default
-            behavior is to have no timeout, e.g. `86400`.
-        idempotency_token:
-            An optional token that can be used to guarantee the idempotency of job
-            run requests. If a run with the provided token already
-            exists, the request does not create a new run but returns
-            the ID of the existing run instead. If a run with the
-            provided token is deleted, an error is returned.  If you
-            specify the idempotency token, upon failure you can retry
-            until the request succeeds. Databricks guarantees that
-            exactly one run is launched with that idempotency token.
-            This token must have at most 64 characters.  For more
-            information, see [How to ensure idempotency for
-            jobs](https://kb.databricks.com/jobs/jobs-idempotency.html),
-            e.g. `8f018174-4792-40d5-bcbc-3e6a527352c8`.
-        access_control_list:
-            List of permissions to set on the job.
-        max_wait_seconds: Maximum number of seconds to wait for the entire flow to complete.
-        poll_frequency_seconds: Number of seconds to wait in between checks for
-            run completion.
-        **jobs_runs_submit_kwargs: Additional keyword arguments to pass to `jobs_runs_submit`.
-
-    Returns:
-        A dictionary of task keys to its corresponding notebook output.
-
-    Examples:
-        Submit jobs runs and wait.
-        ```python
-        from prefect import flow
-        from prefect_databricks import DatabricksCredentials
-        from prefect_databricks.flows import jobs_runs_submit_and_wait_for_completion
-        from prefect_databricks.models.jobs import (
-            AutoScale,
-            AwsAttributes,
-            JobTaskSettings,
-            NotebookTask,
-            NewCluster,
-        )
-
-        @flow
-        def jobs_runs_submit_and_wait_for_completion_flow(notebook_path, **base_parameters):
-            databricks_credentials = await DatabricksCredentials.load("BLOCK_NAME")
-
-            # specify new cluster settings
-            aws_attributes = AwsAttributes(
-                availability="SPOT",
-                zone_id="us-west-2a",
-                ebs_volume_type="GENERAL_PURPOSE_SSD",
-                ebs_volume_count=3,
-                ebs_volume_size=100,
-            )
-            auto_scale = AutoScale(min_workers=1, max_workers=2)
-            new_cluster = NewCluster(
-                aws_attributes=aws_attributes,
-                autoscale=auto_scale,
-                node_type_id="m4.large",
-                spark_version="10.4.x-scala2.12",
-                spark_conf={"spark.speculation": True},
-            )
-
-            # specify notebook to use and parameters to pass
-            notebook_task = NotebookTask(
-                notebook_path=notebook_path,
-                base_parameters=base_parameters,
-            )
-
-            # compile job task settings
-            job_task_settings = JobTaskSettings(
-                new_cluster=new_cluster,
-                notebook_task=notebook_task,
-                task_key="prefect-task"
-            )
-
-            multi_task_runs = jobs_runs_submit_and_wait_for_completion(
-                databricks_credentials=databricks_credentials,
-                run_name="prefect-job",
-                tasks=[job_task_settings]
-            )
-
-            return multi_task_runs
-        ```
-    """  # noqa
     logger = get_run_logger()
 
     # submit the jobs runs
@@ -254,6 +83,7 @@ async def jobs_runs_submit_and_wait_for_completion(
         access_control_list=access_control_list,
         **jobs_runs_submit_kwargs,
     )
+
     multi_task_jobs_runs = await multi_task_jobs_runs_future.result()
     multi_task_jobs_runs_id = multi_task_jobs_runs["run_id"]
 
@@ -303,6 +133,105 @@ async def jobs_runs_submit_and_wait_for_completion(
         raise DatabricksJobSkipped(
             f"Databricks Jobs Runs Submit ({run_name} ID "
             f"{multi_task_jobs_runs_id}) was skipped: {jobs_runs_state_message}.",
+        )
+    elif jobs_runs_life_cycle_state == RunLifeCycleState.internalerror.value:
+        raise DatabricksJobInternalError(
+            f"Databricks Jobs Runs Submit ({run_name} ID "
+            f"{multi_task_jobs_runs_id}) "
+            f"encountered an internal error: {jobs_runs_state_message}.",
+        )
+
+
+@flow(
+    name="Submit existing job runs and wait for completion",
+    description=(
+        "Triggers a Databricks jobs runs and waits for the "
+        "triggered runs to complete."
+    ),
+)
+async def jobs_runs_submit_by_id_and_wait_for_completion(
+    databricks_credentials: DatabricksCredentials,
+    job_id: Optional[int] = None,
+    idempotency_token: Optional[str] = None,
+    jar_params: Optional[List[str]] = None,
+    max_wait_seconds: int = 900,
+    poll_frequency_seconds: int = 10,
+    notebook_params: Optional[Dict] = None,
+    python_params: Optional[List[str]] = None,
+    spark_submit_params: Optional[List[str]] = None,
+    python_named_params: Optional[Dict] = None,
+    pipeline_params: Optional[str] = None,
+    sql_params: Optional[Dict] = None,
+    dbt_commands: Optional[List] = None,
+    **jobs_runs_submit_kwargs: Dict[str, Any],
+) -> Dict:
+    logger = get_run_logger()
+
+    # submit the jobs runs
+
+    jobs_runs_future = await jobs_run_now.submit(
+        databricks_credentials=databricks_credentials,
+        job_id=job_id,
+        idempotency_token=idempotency_token,
+        jar_params=jar_params,
+        notebook_params=notebook_params,
+        python_params=python_params,
+        spark_submit_params=spark_submit_params,
+        python_named_params=python_named_params,
+        pipeline_params=pipeline_params,
+        sql_params=sql_params,
+        dbt_commands=dbt_commands,
+        **jobs_runs_submit_kwargs,
+    )
+
+    jobs_runs = await jobs_runs_future.result()
+    # jobs_runs_id = jobs_runs["run_id"]
+
+    # wait for all the jobs runs to complete in a separate flow
+    # for a cleaner radar interface
+    jobs_runs_state, jobs_runs_metadata = await jobs_runs_wait_for_completion(
+        multi_task_jobs_runs_id=job_id,
+        databricks_credentials=databricks_credentials,
+        max_wait_seconds=max_wait_seconds,
+        poll_frequency_seconds=poll_frequency_seconds,
+    )
+
+    # fetch the state results
+    jobs_runs_life_cycle_state = jobs_runs_state["life_cycle_state"]
+    jobs_runs_state_message = jobs_runs_state["state_message"]
+
+    # return results or raise error
+    if jobs_runs_life_cycle_state == RunLifeCycleState.terminated.value:
+        jobs_runs_result_state = jobs_runs_state.get("result_state", None)
+        if jobs_runs_result_state == RunResultState.success.value:
+            task_notebook_outputs = {}
+            for task in jobs_runs_metadata["tasks"]:
+                task_key = task["task_key"]
+                task_run_id = task["run_id"]
+                task_run_output_future = await jobs_runs_get_output.submit(
+                    run_id=task_run_id,
+                    databricks_credentials=databricks_credentials,
+                )
+                task_run_output = await task_run_output_future.result()
+                task_run_notebook_output = task_run_output.get("notebook_output", {})
+                task_notebook_outputs[task_key] = task_run_notebook_output
+            logger.info(
+                "Databricks Jobs Runs Submit (%s ID %s) completed successfully!",
+                run_name,
+                job_id,
+            )
+            return task_notebook_outputs
+        else:
+            raise DatabricksJobTerminated(
+                f"Databricks Jobs Runs Submit "
+                f"({run_name} ID {job_id}) "
+                f"terminated with result state, {jobs_runs_result_state}: "
+                f"{jobs_runs_state_message}"
+            )
+    elif jobs_runs_life_cycle_state == RunLifeCycleState.skipped.value:
+        raise DatabricksJobSkipped(
+            f"Databricks Jobs Runs Submit ({run_name} ID "
+            f"{job_id}) was skipped: {jobs_runs_state_message}.",
         )
     elif jobs_runs_life_cycle_state == RunLifeCycleState.internalerror.value:
         raise DatabricksJobInternalError(

--- a/prefect_databricks/flows.py
+++ b/prefect_databricks/flows.py
@@ -255,7 +255,6 @@ async def jobs_runs_submit_and_wait_for_completion(
     jobs_runs_state, jobs_runs_metadata = await jobs_runs_wait_for_completion(
         multi_task_jobs_runs_id=multi_task_jobs_runs_id,
         databricks_credentials=databricks_credentials,
-        submit_by_id=False,
         run_name=run_name,
         max_wait_seconds=max_wait_seconds,
         poll_frequency_seconds=poll_frequency_seconds,
@@ -451,7 +450,6 @@ async def jobs_runs_submit_by_id_and_wait_for_completion(
     jobs_runs_state, jobs_runs_metadata = await jobs_runs_wait_for_completion(
         multi_task_jobs_runs_id=job_run_id,
         databricks_credentials=databricks_credentials,
-        submit_by_id=True,
         max_wait_seconds=max_wait_seconds,
         poll_frequency_seconds=poll_frequency_seconds,
     )
@@ -499,7 +497,6 @@ def _update_and_log_state_changes(
     job_or_task_states: Dict[str, Any],
     job_or_task_metadata: Dict[str, Any],
     logger: Logger,
-    submit_by_id: bool,
     run_type: str = "Task",
 ) -> Dict[str, Any]:
     """
@@ -573,7 +570,6 @@ def _update_and_log_state_changes(
 async def jobs_runs_wait_for_completion(
     multi_task_jobs_runs_id: int,
     databricks_credentials: DatabricksCredentials,
-    submit_by_id: bool,
     run_name: Optional[str] = None,
     max_wait_seconds: int = 900,
     poll_frequency_seconds: int = 10,
@@ -631,12 +627,12 @@ async def jobs_runs_wait_for_completion(
 
         jobs_runs_metadata = await jobs_runs_metadata_future.result()
         jobs_status = _update_and_log_state_changes(
-            jobs_status, jobs_runs_metadata, logger, submit_by_id, b"Job"
+            jobs_status, jobs_runs_metadata, logger, b"Job"
         )
         jobs_runs_metadata_tasks = jobs_runs_metadata.get("tasks", [])
         for task_metadata in jobs_runs_metadata_tasks:
             tasks_status = _update_and_log_state_changes(
-                tasks_status, task_metadata, logger, submit_by_id, "Task"
+                tasks_status, task_metadata, logger, "Task"
             )
 
         jobs_runs_state = jobs_runs_metadata.get("state", {})

--- a/prefect_databricks/flows.py
+++ b/prefect_databricks/flows.py
@@ -10,10 +10,10 @@ from prefect import flow, get_run_logger
 
 from prefect_databricks import DatabricksCredentials
 from prefect_databricks.jobs import (
+    jobs_run_now,
     jobs_runs_get,
     jobs_runs_get_output,
     jobs_runs_submit,
-    jobs_run_now,
 )
 from prefect_databricks.models.jobs import (
     AccessControlRequest,
@@ -214,26 +214,26 @@ async def jobs_runs_submit_by_id_and_wait_for_completion(
             )
             task_run_output = await task_run_output_future.result()
             task_run_notebook_output = task_run_output.get("notebook_output", {})
+            task_notebook_outputs[task_run_id] = task_run_notebook_output
             logger.info(
-                "Databricks Jobs Runs Submit (%s ID %s) completed successfully!",
-                job_id,
+                f"Databricks Jobs Runs Submit {jobs_runs_id} completed successfully!",
             )
             return task_notebook_outputs
         else:
             raise DatabricksJobTerminated(
-                f"Databricks Jobs Runs Submit ID {job_id}"
+                f"Databricks Jobs Runs Submit ID {jobs_runs_id}"
                 f"terminated with result state, {jobs_runs_result_state}: "
                 f"{jobs_runs_state_message}"
             )
     elif jobs_runs_life_cycle_state == RunLifeCycleState.skipped.value:
         raise DatabricksJobSkipped(
             f"Databricks Jobs Runs Submit ID "
-            f"{job_id} was skipped: {jobs_runs_state_message}.",
+            f"{jobs_runs_id} was skipped: {jobs_runs_state_message}.",
         )
     elif jobs_runs_life_cycle_state == RunLifeCycleState.internalerror.value:
         raise DatabricksJobInternalError(
             f"Databricks Jobs Runs Submit ID "
-            f"{job_id} "
+            f"{jobs_runs_id} "
             f"encountered an internal error: {jobs_runs_state_message}.",
         )
 

--- a/prefect_databricks/flows.py
+++ b/prefect_databricks/flows.py
@@ -327,7 +327,7 @@ async def jobs_runs_submit_by_id_and_wait_for_completion(
     pipeline_params: Optional[str] = None,
     sql_params: Optional[Dict] = None,
     dbt_commands: Optional[List] = None,
-    **jobs_runs_submit_kwargs,
+    **jobs_runs_submit_kwargs: Dict[str, Any],
 ) -> Dict:
     """flow that triggers an existing job and waits for its completion
 

--- a/prefect_databricks/flows.py
+++ b/prefect_databricks/flows.py
@@ -460,16 +460,13 @@ async def jobs_runs_submit_by_id_and_wait_for_completion(
         jobs_runs_result_state = jobs_runs_state.get("result_state", None)
         if jobs_runs_result_state == RunResultState.success.value:
             task_notebook_outputs = {}
-            # for task in jobs_runs_metadata["tasks"]:
-            # task_key = task["task_key"]
-            task_run_id = jobs_runs_metadata["run_id"]
             task_run_output_future = await jobs_runs_get_output.submit(
-                run_id=task_run_id,
+                run_id=jobs_runs_id,
                 databricks_credentials=databricks_credentials,
             )
             task_run_output = await task_run_output_future.result()
             task_run_notebook_output = task_run_output.get("notebook_output", {})
-            task_notebook_outputs[task_run_id] = task_run_notebook_output
+            task_notebook_outputs[jobs_runs_id] = task_run_notebook_output
             logger.info(
                 f"Databricks Jobs Runs Submit {jobs_runs_id} completed successfully!",
             )

--- a/prefect_databricks/flows.py
+++ b/prefect_databricks/flows.py
@@ -333,20 +333,20 @@ async def jobs_runs_submit_by_id_and_wait_for_completion(
     Args:
         databricks_credentials (DatabricksCredentials):
             Credentials to use for authentication with Databricks.
-        job_id (Optional[int], optional): _description_. Id of the databricks job.
-        idempotency_token (Optional[str], optional): _description_. Defaults to None.
-        jar_params (Optional[List[str]], optional):
+        job_id: Id of the databricks job.
+        idempotency_token: _description_. Defaults to None.
+        jar_params:
             A list of parameters for jobs with Spark JAR tasks, for example "jar_params"
             : ["john doe", "35"]. The parameters are used to invoke the main function of
             the main class specified in the Spark JAR task. If not specified upon run-
             now, it defaults to an empty list. jar_params cannot be specified in
             conjunction with notebook_params. The JSON representation of this field (for
             example {"jar_params": ["john doe","35"]}) cannot exceed 10,000 bytes.
-        max_wait_seconds (int, optional):
+        max_wait_seconds:
             Maximum number of seconds to wait for the entire flow to complete.
         poll_frequency_seconds: Number of seconds to wait in between checks for
             run completion.
-        notebook_params (Optional[Dict], optional):
+        notebook_params:
             A map from keys to values for jobs with notebook task, for example
             "notebook_params": {"name": "john doe", "age": "35"}. The map is
             passed to the notebook and is accessible through the dbutils.widgets.get
@@ -356,7 +356,7 @@ async def jobs_runs_submit_by_id_and_wait_for_completion(
             information about job runs. The JSON representation of this field
             (for example {"notebook_params":{"name":"john doe","age":"35"}}) cannot
             exceed 10,000 bytes.
-        python_params (Optional[List[str]], optional):
+        python_params:
             A list of parameters for jobs with Python tasks, for example "python_params"
             :["john doe", "35"]. The parameters are passed to Python file as command-
             line parameters. If specified upon run-now, it would overwrite the
@@ -366,7 +366,7 @@ async def jobs_runs_submit_by_id_and_wait_for_completion(
             about job runs. These parameters accept only Latin characters (ASCII
             character set). Using non-ASCII characters returns an error. Examples of
             invalid, non-ASCII characters are Chinese, Japanese kanjis, and emojis.
-        spark_submit_params (Optional[List[str]], optional):
+        spark_submit_params:
             A list of parameters for jobs with spark submit task, for example
             "spark_submit_params": ["--class", "org.apache.spark.examples.SparkPi"].
             The parameters are passed to spark-submit script as command-line parameters.
@@ -377,15 +377,15 @@ async def jobs_runs_submit_by_id_and_wait_for_completion(
             job runs. These parameters accept only Latin characters (ASCII character
             set). Using non-ASCII characters returns an error. Examples of invalid,
             non-ASCII characters are Chinese, Japanese kanjis, and emojis.
-        python_named_params (Optional[Dict], optional):
+        python_named_params:
             A map from keys to values for jobs with Python wheel task, for example
             "python_named_params": {"name": "task", "data": "dbfs:/path/to/data.json"}.
         pipeline_params (Optional[str], optional): Defaults to None.
-        sql_params (Optional[Dict], optional):
+        sql_params:
             A map from keys to values for SQL tasks, for example "sql_params":
             {"name": "john doe", "age": "35"}. The SQL alert task does not support
             custom parameters.
-        dbt_commands (Optional[List], optional):
+        dbt_commands:
             An array of commands to execute for jobs with the dbt task,
             for example "dbt_commands": ["dbt deps", "dbt seed", "dbt run"]
 

--- a/prefect_databricks/flows.py
+++ b/prefect_databricks/flows.py
@@ -195,7 +195,6 @@ async def jobs_runs_submit_by_id_and_wait_for_completion(
         max_wait_seconds=max_wait_seconds,
         poll_frequency_seconds=poll_frequency_seconds,
     )
-    print(jobs_runs_metadata)
 
     # fetch the state results
     jobs_runs_life_cycle_state = jobs_runs_state["life_cycle_state"]
@@ -215,8 +214,6 @@ async def jobs_runs_submit_by_id_and_wait_for_completion(
             )
             task_run_output = await task_run_output_future.result()
             task_run_notebook_output = task_run_output.get("notebook_output", {})
-            print(task_run_notebook_output)
-            # task_notebook_outputs[task_key] = task_run_notebook_output
             logger.info(
                 "Databricks Jobs Runs Submit (%s ID %s) completed successfully!",
                 job_id,

--- a/prefect_databricks/flows.py
+++ b/prefect_databricks/flows.py
@@ -217,26 +217,24 @@ async def jobs_runs_submit_by_id_and_wait_for_completion(
                 task_notebook_outputs[task_key] = task_run_notebook_output
             logger.info(
                 "Databricks Jobs Runs Submit (%s ID %s) completed successfully!",
-                run_name,
                 job_id,
             )
             return task_notebook_outputs
         else:
             raise DatabricksJobTerminated(
-                f"Databricks Jobs Runs Submit "
-                f"({run_name} ID {job_id}) "
+                f"Databricks Jobs Runs Submit ID {job_id}"
                 f"terminated with result state, {jobs_runs_result_state}: "
                 f"{jobs_runs_state_message}"
             )
     elif jobs_runs_life_cycle_state == RunLifeCycleState.skipped.value:
         raise DatabricksJobSkipped(
-            f"Databricks Jobs Runs Submit ({run_name} ID "
-            f"{job_id}) was skipped: {jobs_runs_state_message}.",
+            f"Databricks Jobs Runs Submit ID "
+            f"{job_id} was skipped: {jobs_runs_state_message}.",
         )
     elif jobs_runs_life_cycle_state == RunLifeCycleState.internalerror.value:
         raise DatabricksJobInternalError(
-            f"Databricks Jobs Runs Submit ({run_name} ID "
-            f"{multi_task_jobs_runs_id}) "
+            f"Databricks Jobs Runs Submit ID "
+            f"{job_id} "
             f"encountered an internal error: {jobs_runs_state_message}.",
         )
 

--- a/prefect_databricks/flows.py
+++ b/prefect_databricks/flows.py
@@ -380,7 +380,7 @@ async def jobs_runs_submit_by_id_and_wait_for_completion(
         python_named_params:
             A map from keys to values for jobs with Python wheel task, for example
             "python_named_params": {"name": "task", "data": "dbfs:/path/to/data.json"}.
-        pipeline_params (Optional[str], optional): Defaults to None.
+        pipeline_params: Defaults to None.
         sql_params:
             A map from keys to values for SQL tasks, for example "sql_params":
             {"name": "john doe", "age": "35"}. The SQL alert task does not support

--- a/prefect_databricks/flows.py
+++ b/prefect_databricks/flows.py
@@ -314,7 +314,7 @@ async def jobs_runs_submit_and_wait_for_completion(
 )
 async def jobs_runs_submit_by_id_and_wait_for_completion(
     databricks_credentials: DatabricksCredentials,
-    job_id: int = None,
+    job_id: int,
     idempotency_token: Optional[str] = None,
     jar_params: Optional[List[str]] = None,
     max_wait_seconds: int = 900,

--- a/prefect_databricks/flows.py
+++ b/prefect_databricks/flows.py
@@ -333,7 +333,19 @@ async def jobs_runs_submit_by_id_and_wait_for_completion(
     Args:
         databricks_credentials: Credentials to use for authentication with Databricks.
         job_id: Id of the databricks job.
-        idempotency_token: _description_. Defaults to None.
+        idempotency_token:
+            An optional token that can be used to guarantee the idempotency of job
+            run requests. If a run with the provided token already
+            exists, the request does not create a new run but returns
+            the ID of the existing run instead. If a run with the
+            provided token is deleted, an error is returned.  If you
+            specify the idempotency token, upon failure you can retry
+            until the request succeeds. Databricks guarantees that
+            exactly one run is launched with that idempotency token.
+            This token must have at most 64 characters.  For more
+            information, see [How to ensure idempotency for
+            jobs](https://kb.databricks.com/jobs/jobs-idempotency.html),
+            e.g. `8f018174-4792-40d5-bcbc-3e6a527352c8`.
         jar_params:
             A list of parameters for jobs with Spark JAR tasks, for example "jar_params"
             : ["john doe", "35"]. The parameters are used to invoke the main function of
@@ -379,7 +391,12 @@ async def jobs_runs_submit_by_id_and_wait_for_completion(
         python_named_params:
             A map from keys to values for jobs with Python wheel task, for example
             "python_named_params": {"name": "task", "data": "dbfs:/path/to/data.json"}.
-        pipeline_params: Defaults to None.
+        pipeline_params:
+            If `full_refresh` is set to true, trigger a full refresh on the
+            delta live table e.g.
+            ```
+                "pipeline_params": {"full_refresh": true}
+            ```
         sql_params:
             A map from keys to values for SQL tasks, for example "sql_params":
             {"name": "john doe", "age": "35"}. The SQL alert task does not support

--- a/prefect_databricks/flows.py
+++ b/prefect_databricks/flows.py
@@ -331,8 +331,7 @@ async def jobs_runs_submit_by_id_and_wait_for_completion(
     """flow that triggers an existing job and waits for its completion
 
     Args:
-        databricks_credentials (DatabricksCredentials):
-            Credentials to use for authentication with Databricks.
+        databricks_credentials: Credentials to use for authentication with Databricks.
         job_id: Id of the databricks job.
         idempotency_token: _description_. Defaults to None.
         jar_params:

--- a/prefect_databricks/flows.py
+++ b/prefect_databricks/flows.py
@@ -391,9 +391,12 @@ async def jobs_runs_submit_by_id_and_wait_for_completion(
             for example "dbt_commands": ["dbt deps", "dbt seed", "dbt run"]
 
     Raises:
-        DatabricksJobTerminated: Raised when the Databricks job run is terminated with a non-successful result state.
+        DatabricksJobTerminated:
+            Raised when the Databricks job run is terminated with a non-successful
+            result state.
         DatabricksJobSkipped: Raised when the Databricks job run is skipped.
-        DatabricksJobInternalError: Raised when the Databricks job run encounters an internal error.
+        DatabricksJobInternalError:
+            Raised when the Databricks job run encounters an internal error.
 
     Returns:
         Dict: A dictionary containing information about the completed job run.

--- a/prefect_databricks/jobs.py
+++ b/prefect_databricks/jobs.py
@@ -1138,7 +1138,7 @@ async def jobs_runs_get(
         Upon success, a dict of the response. </br>- `job_id: int`</br>- `run_id: int`</br>- `number_in_job: int`</br>- `creator_user_name: str`</br>- `original_attempt_run_id: int`</br>- `state: "models.RunState"`</br>- `schedule: "models.CronSchedule"`</br>- `tasks: List["models.RunTask"]`</br>- `job_clusters: List["models.JobCluster"]`</br>- `cluster_spec: "models.ClusterSpec"`</br>- `cluster_instance: "models.ClusterInstance"`</br>- `git_source: "models.GitSource"`</br>- `overriding_parameters: "models.RunParameters"`</br>- `start_time: int`</br>- `setup_duration: int`</br>- `execution_duration: int`</br>- `cleanup_duration: int`</br>- `end_time: int`</br>- `trigger: "models.TriggerType"`</br>- `run_name: str`</br>- `run_page_url: str`</br>- `run_type: "models.RunType"`</br>- `attempt_number: int`</br>- `repair_history: List["models.RepairHistoryItem"]`</br>
 
     <h4>API Endpoint:</h4>
-    `/2.0/jobs/runs/get`
+    `/2.1/jobs/runs/get`
 
     <h4>API Responses:</h4>
     | Response | Description |
@@ -1148,7 +1148,7 @@ async def jobs_runs_get(
     | 401 | The request was unauthorized. |
     | 500 | The request was not handled correctly due to a server error. |
     """  # noqa
-    endpoint = "/2.0/jobs/runs/get"  # noqa
+    endpoint = "/2.1/jobs/runs/get"  # noqa
 
     responses = {
         200: "Run was retrieved successfully.",  # noqa
@@ -1210,7 +1210,7 @@ async def jobs_runs_get_output(
     | 401 | The request was unauthorized. |
     | 500 | The request was not handled correctly due to a server error. |
     """  # noqa
-    endpoint = "/2.0/jobs/runs/get-output"  # noqa
+    endpoint = "/2.1/jobs/runs/get-output"  # noqa
 
     responses = {
         200: "Run output was retrieved successfully.",  # noqa

--- a/prefect_databricks/jobs.py
+++ b/prefect_databricks/jobs.py
@@ -784,7 +784,7 @@ async def jobs_reset(
 @task
 async def jobs_run_now(
     databricks_credentials: "DatabricksCredentials",
-    job_id: Optional[int] = None,
+    job_id: int,
     idempotency_token: Optional[str] = None,
     jar_params: Optional[List[str]] = None,
     notebook_params: Optional[Dict] = None,
@@ -894,6 +894,11 @@ async def jobs_run_now(
             {"name": "task", "data": "dbfs:/path/to/data.json"}
             ```
         pipeline_params:
+            If `full_refresh` is set to true, trigger a full refresh on the
+            delta live table e.g.
+            ```
+                "pipeline_params": {"full_refresh": true}
+            ```
 
         sql_params:
             A map from keys to values for SQL tasks, for example `'sql_params':

--- a/prefect_databricks/jobs.py
+++ b/prefect_databricks/jobs.py
@@ -1138,7 +1138,7 @@ async def jobs_runs_get(
         Upon success, a dict of the response. </br>- `job_id: int`</br>- `run_id: int`</br>- `number_in_job: int`</br>- `creator_user_name: str`</br>- `original_attempt_run_id: int`</br>- `state: "models.RunState"`</br>- `schedule: "models.CronSchedule"`</br>- `tasks: List["models.RunTask"]`</br>- `job_clusters: List["models.JobCluster"]`</br>- `cluster_spec: "models.ClusterSpec"`</br>- `cluster_instance: "models.ClusterInstance"`</br>- `git_source: "models.GitSource"`</br>- `overriding_parameters: "models.RunParameters"`</br>- `start_time: int`</br>- `setup_duration: int`</br>- `execution_duration: int`</br>- `cleanup_duration: int`</br>- `end_time: int`</br>- `trigger: "models.TriggerType"`</br>- `run_name: str`</br>- `run_page_url: str`</br>- `run_type: "models.RunType"`</br>- `attempt_number: int`</br>- `repair_history: List["models.RepairHistoryItem"]`</br>
 
     <h4>API Endpoint:</h4>
-    `/2.1/jobs/runs/get`
+    `/2.0/jobs/runs/get`
 
     <h4>API Responses:</h4>
     | Response | Description |
@@ -1678,7 +1678,7 @@ async def jobs_runs_submit(
         Upon success, a dict of the response. </br>- `run_id: int`</br>
 
     <h4>API Endpoint:</h4>
-    `/2.1/jobs/runs/submit`
+    `/2.0/jobs/runs/submit`
 
     <h4>API Responses:</h4>
     | Response | Description |
@@ -1688,7 +1688,7 @@ async def jobs_runs_submit(
     | 401 | The request was unauthorized. |
     | 500 | The request was not handled correctly due to a server error. |
     """  # noqa
-    endpoint = "/2.1/jobs/runs/submit"  # noqa
+    endpoint = "/2.0/jobs/runs/submit"  # noqa
 
     responses = {
         200: "Run was created and started successfully.",  # noqa

--- a/prefect_databricks/jobs.py
+++ b/prefect_databricks/jobs.py
@@ -923,7 +923,7 @@ async def jobs_run_now(
     | 401 | The request was unauthorized. |
     | 500 | The request was not handled correctly due to a server error. |
     """  # noqa
-    endpoint = "/2.1/jobs/run-now"  # noqa
+    endpoint = "2.1/jobs/run-now"  # noqa
 
     responses = {
         200: "Run was started successfully.",  # noqa
@@ -1148,7 +1148,7 @@ async def jobs_runs_get(
     | 401 | The request was unauthorized. |
     | 500 | The request was not handled correctly due to a server error. |
     """  # noqa
-    endpoint = "/2.1/jobs/runs/get"  # noqa
+    endpoint = "/2.0/jobs/runs/get"  # noqa
 
     responses = {
         200: "Run was retrieved successfully.",  # noqa
@@ -1210,7 +1210,7 @@ async def jobs_runs_get_output(
     | 401 | The request was unauthorized. |
     | 500 | The request was not handled correctly due to a server error. |
     """  # noqa
-    endpoint = "/2.1/jobs/runs/get-output"  # noqa
+    endpoint = "/2.0/jobs/runs/get-output"  # noqa
 
     responses = {
         200: "Run output was retrieved successfully.",  # noqa

--- a/prefect_databricks/jobs.py
+++ b/prefect_databricks/jobs.py
@@ -923,7 +923,7 @@ async def jobs_run_now(
     | 401 | The request was unauthorized. |
     | 500 | The request was not handled correctly due to a server error. |
     """  # noqa
-    endpoint = "2.1/jobs/run-now"  # noqa
+    endpoint = "/2.1/jobs/run-now"  # noqa
 
     responses = {
         200: "Run was started successfully.",  # noqa

--- a/prefect_databricks/jobs.py
+++ b/prefect_databricks/jobs.py
@@ -1678,7 +1678,7 @@ async def jobs_runs_submit(
         Upon success, a dict of the response. </br>- `run_id: int`</br>
 
     <h4>API Endpoint:</h4>
-    `/2.0/jobs/runs/submit`
+    `/2.1/jobs/runs/submit`
 
     <h4>API Responses:</h4>
     | Response | Description |
@@ -1688,7 +1688,7 @@ async def jobs_runs_submit(
     | 401 | The request was unauthorized. |
     | 500 | The request was not handled correctly due to a server error. |
     """  # noqa
-    endpoint = "/2.0/jobs/runs/submit"  # noqa
+    endpoint = "/2.1/jobs/runs/submit"  # noqa
 
     responses = {
         200: "Run was created and started successfully.",  # noqa

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -371,7 +371,7 @@ class TestJobsRunsIdSubmitAndWaitForCompletion:
     @pytest.mark.respx(assert_all_called=True)
     async def test_run_success(self, common_mocks, respx_mock, databricks_credentials):
         respx_mock.get(
-            "https://dbc-1d3d172b-59e4.cloud.databricks.com/api/2.1/jobs/runs/get?run_id=36108",  # noqa
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.1/jobs/runs/get?run_id=36108",  # noqa
             headers={"Authorization": "Bearer testing_token"},
         ).mock(
             return_value=Response(

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -34,7 +34,9 @@ def run_now_mocks(respx_mock):
     respx_mock.post(
         "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.1/jobs/run-now",
         headers={"Authorization": "Bearer testing_token"},
-    ).mock(return_value=Response(200, json={"run_id": 36108, "number_in_job": 36108}))
+    ).mock(
+        return_value=Response(200, json={"run_id": 11223344, "number_in_job": 11223344})
+    )
 
 
 @pytest.fixture
@@ -42,7 +44,7 @@ def common_mocks(respx_mock):
     respx_mock.post(
         "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/submit",
         headers={"Authorization": "Bearer testing_token"},
-    ).mock(return_value=Response(200, json={"run_id": 36108}))
+    ).mock(return_value=Response(200, json={"run_id": 11223344}))
 
 
 def successful_job_path(request, route):
@@ -50,7 +52,7 @@ def successful_job_path(request, route):
         return Response(
             200,
             json={
-                "run_id": 36108,
+                "run_id": 11223344,
                 "state": {
                     "life_cycle_state": "RUNNING",
                     "state_message": "",
@@ -58,7 +60,7 @@ def successful_job_path(request, route):
                 },
                 "tasks": [
                     {
-                        "run_id": 36260,
+                        "run_id": 11223344,
                         "task_key": "prefect-task",
                         "state": {
                             "life_cycle_state": "PENDING",
@@ -73,7 +75,7 @@ def successful_job_path(request, route):
         return Response(
             200,
             json={
-                "run_id": 36108,
+                "run_id": 11223344,
                 "state": {
                     "life_cycle_state": "RUNNING",
                     "state_message": "",
@@ -81,7 +83,7 @@ def successful_job_path(request, route):
                 },
                 "tasks": [
                     {
-                        "run_id": 36260,
+                        "run_id": 11223344,
                         "task_key": "prefect-task",
                         "state": {
                             "life_cycle_state": "RUNNING",
@@ -96,7 +98,7 @@ def successful_job_path(request, route):
         return Response(
             200,
             json={
-                "run_id": 36108,
+                "run_id": 11223344,
                 "state": {
                     "life_cycle_state": "TERMINATED",
                     "state_message": "",
@@ -104,7 +106,7 @@ def successful_job_path(request, route):
                 },
                 "tasks": [
                     {
-                        "run_id": 36260,
+                        "run_id": 11223344,
                         "task_key": "prefect-task",
                         "state": {
                             "life_cycle_state": "TERMINATED",
@@ -121,7 +123,7 @@ class TestJobsRunsSubmitAndWaitForCompletion:
     @pytest.mark.respx(assert_all_called=True)
     async def test_run_success(self, common_mocks, respx_mock, databricks_credentials):
         respx_mock.get(
-            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=36108",  # noqa
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=11223344",  # noqa
             headers={"Authorization": "Bearer testing_token"},
         ).mock(
             return_value=Response(
@@ -132,7 +134,7 @@ class TestJobsRunsSubmitAndWaitForCompletion:
                         "state_message": "",
                         "result_state": "SUCCESS",
                     },
-                    "tasks": [{"run_id": 36260, "task_key": "prefect-task"}],
+                    "tasks": [{"run_id": 11223344, "task_key": "prefect-task"}],
                 },
             )
         )
@@ -162,7 +164,7 @@ class TestJobsRunsSubmitAndWaitForCompletion:
         self, common_mocks, respx_mock, databricks_credentials
     ):
         respx_mock.get(
-            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=36108",  # noqa
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=11223344",  # noqa
             headers={"Authorization": "Bearer testing_token"},
         ).mock(side_effect=successful_job_path)
 
@@ -195,7 +197,7 @@ class TestJobsRunsSubmitAndWaitForCompletion:
         self, result_state, common_mocks, respx_mock, databricks_credentials
     ):
         respx_mock.get(
-            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=36108",  # noqa
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=11223344",  # noqa
             headers={"Authorization": "Bearer testing_token"},
         ).mock(
             return_value=Response(
@@ -206,13 +208,13 @@ class TestJobsRunsSubmitAndWaitForCompletion:
                         "state_message": "testing",
                         "result_state": result_state,
                     },
-                    "tasks": [{"run_id": 36260, "task_key": "prefect-task"}],
+                    "tasks": [{"run_id": 11223344, "task_key": "prefect-task"}],
                 },
             )
         )
 
         match = re.escape(  # escape to handle the parentheses
-            f"Databricks Jobs Runs Submit (prefect-job ID 36108) "
+            f"Databricks Jobs Runs Submit (prefect-job ID 11223344) "
             f"terminated with result state, {result_state}: testing"
         )
         with pytest.raises(DatabricksJobTerminated, match=match):
@@ -233,7 +235,7 @@ class TestJobsRunsSubmitAndWaitForCompletion:
     @pytest.mark.respx(assert_all_called=True)
     async def test_run_skipped(self, common_mocks, respx_mock, databricks_credentials):
         respx_mock.get(
-            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=36108",  # noqa
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=11223344",  # noqa
             headers={"Authorization": "Bearer testing_token"},
         ).mock(
             return_value=Response(
@@ -243,13 +245,13 @@ class TestJobsRunsSubmitAndWaitForCompletion:
                         "life_cycle_state": "SKIPPED",
                         "state_message": "testing",
                     },
-                    "tasks": [{"run_id": 36260, "task_key": "prefect-task"}],
+                    "tasks": [{"run_id": 11223344, "task_key": "prefect-task"}],
                 },
             )
         )
 
         match = re.escape(  # escape to handle the parentheses
-            "Databricks Jobs Runs Submit (prefect-job ID 36108) "
+            "Databricks Jobs Runs Submit (prefect-job ID 11223344) "
             "was skipped: testing."
         )
         with pytest.raises(DatabricksJobSkipped, match=match):
@@ -272,7 +274,7 @@ class TestJobsRunsSubmitAndWaitForCompletion:
         self, common_mocks, respx_mock, databricks_credentials
     ):
         respx_mock.get(
-            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=36108",  # noqa
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=11223344",  # noqa
             headers={"Authorization": "Bearer testing_token"},
         ).mock(
             return_value=Response(
@@ -282,17 +284,17 @@ class TestJobsRunsSubmitAndWaitForCompletion:
                         "life_cycle_state": "INTERNAL_ERROR",
                         "state_message": "testing",
                     },
-                    "tasks": [{"run_id": 36260, "task_key": "prefect-task"}],
+                    "tasks": [{"run_id": 11223344, "task_key": "prefect-task"}],
                 },
             )
         )
 
         match = re.escape(  # escape to handle the parentheses
-            "Databricks Jobs Runs Submit (prefect-job ID 36108) "
+            "Databricks Jobs Runs Submit (prefect-job ID 11223344) "
             "encountered an internal error: testing."
         )
         with pytest.raises(DatabricksJobInternalError, match=match):
-            await jobs_runs_submit_by_id_and_wait_for_completion(
+            await jobs_runs_submit_and_wait_for_completion(
                 databricks_credentials=databricks_credentials,
                 run_name="prefect-job",
                 tasks=[
@@ -311,7 +313,7 @@ class TestJobsRunsSubmitAndWaitForCompletion:
         self, common_mocks, respx_mock, databricks_credentials
     ):
         respx_mock.get(
-            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=36108",  # noqa
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=11223344",  # noqa
             headers={"Authorization": "Bearer testing_token"},
         ).mock(
             return_value=Response(
@@ -322,7 +324,7 @@ class TestJobsRunsSubmitAndWaitForCompletion:
                         "state_message": "",
                         "result_state": "abc",
                     },
-                    "tasks": [{"run_id": 36260, "task_key": "prefect-task"}],
+                    "tasks": [{"run_id": 11223344, "task_key": "prefect-task"}],
                 },
             )
         )
@@ -350,7 +352,7 @@ class TestJobsRunsSubmitAndWaitForCompletion:
         self, common_mocks, respx_mock, databricks_credentials
     ):
         respx_mock.get(
-            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=36108",  # noqa
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=11223344",  # noqa
             headers={"Authorization": "Bearer testing_token"},
         ).mock(
             return_value=Response(
@@ -361,7 +363,7 @@ class TestJobsRunsSubmitAndWaitForCompletion:
                         "state_message": "",
                         "result_state": "SUCCESS",
                     },
-                    "tasks": [{"run_id": 36260, "task_key": "prefect-task"}],
+                    "tasks": [{"run_id": 11223344, "task_key": "prefect-task"}],
                 },
             )
         )
@@ -389,10 +391,18 @@ class TestJobsRunsSubmitAndWaitForCompletion:
 class TestJobsRunsIdSubmitAndWaitForCompletion:
     @pytest.mark.respx(assert_all_called=False)
     async def test_run_now_success(
-        self, run_now_mocks, respx_mock, databricks_credentials
+        self, common_mocks, run_now_mocks, respx_mock, databricks_credentials
     ):
+        respx_mock.post(
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.1/jobs/run-now?job_id=11223344",  # noqa
+            headers={"Authorization": "Bearer testing_token"},
+        ).mock(
+            return_value=Response(
+                200, json={"run_id": 11223344, "number_in_job": 11223344}
+            )
+        )
         respx_mock.get(
-            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=36108",  # noqa
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=11223344",  # noqa
             headers={"Authorization": "Bearer testing_token"},
         ).mock(
             return_value=Response(
@@ -403,15 +413,9 @@ class TestJobsRunsIdSubmitAndWaitForCompletion:
                         "state_message": "",
                         "result_state": "SUCCESS",
                     },
-                    "tasks": [{"run_id": 36260, "task_key": "prefect-task"}],
+                    "tasks": [{"run_id": 11223344, "task_key": "prefect-task"}],
                 },
             )
-        )
-        respx_mock.post(
-            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.1/jobs/run-now?job_id=11223344",  # noqa
-            headers={"Authorization": "Bearer testing_token"},
-        ).mock(
-            return_value=Response(200, json={"run_id": 36108, "number_in_job": 36108})
         )
         respx_mock.get(
             "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get-output",  # noqa
@@ -421,47 +425,123 @@ class TestJobsRunsIdSubmitAndWaitForCompletion:
         result = await jobs_runs_submit_by_id_and_wait_for_completion(
             databricks_credentials=databricks_credentials, job_id=11223344
         )
-        assert result == {36108: {"cell": "output"}}
+        assert result == {11223344: {"cell": "output"}}
 
     @pytest.mark.respx(assert_all_called=False)
-    async def test_run_now_internal_error(
-        self, run_now_mocks, respx_mock, databricks_credentials
+    @pytest.mark.parametrize("result_state", ["FAILED", "TIMEDOUT", "CANCELED"])
+    async def test_run_now_terminated(
+        self,
+        result_state,
+        common_mocks,
+        run_now_mocks,
+        respx_mock,
+        databricks_credentials,
     ):
+        respx_mock.post(
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.1/jobs/run-now?job_id=11223344",  # noqa
+            headers={"Authorization": "Bearer testing_token"},
+        ).mock(
+            return_value=Response(
+                200, json={"run_id": 11223344, "number_in_job": 11223344}
+            )
+        )
         respx_mock.get(
-            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=36108",  # noqa
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=11223344",  # noqa
             headers={"Authorization": "Bearer testing_token"},
         ).mock(
             return_value=Response(
                 200,
                 json={
                     "state": {
-                        "life_cycle_state": "INTERNAL_ERROR",
+                        "life_cycle_state": "TERMINATED",
                         "state_message": "testing",
+                        "result_state": result_state,
                     },
-                    "tasks": [{"run_id": 36260, "task_key": "prefect-task"}],
+                    "tasks": [{"run_id": 11223344, "task_key": "prefect-task"}],
                 },
             )
         )
 
         match = re.escape(  # escape to handle the parentheses
-            "Databricks Jobs Runs Submit (prefect-job ID 36108) "
-            "encountered an internal error: testing."
+            f"Databricks Jobs Runs Submit ID 11223344 "
+            f"terminated with result state, {result_state}: testing"
         )
-        with pytest.raises(DatabricksJobInternalError, match=match):
+        with pytest.raises(DatabricksJobTerminated, match=match):
+            await jobs_runs_submit_by_id_and_wait_for_completion(
+                databricks_credentials=databricks_credentials, job_id=11223344
+            )
+
+    @pytest.mark.respx(assert_all_called=False)
+    async def test_run_now_skipped(
+        self, common_mocks, run_now_mocks, respx_mock, databricks_credentials
+    ):
+        respx_mock.post(
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.1/jobs/run-now?job_id=11223344",  # noqa
+            headers={"Authorization": "Bearer testing_token"},
+        ).mock(
+            return_value=Response(
+                200, json={"run_id": 11223344, "number_in_job": 11223344}
+            )
+        )
+        respx_mock.get(
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=11223344",  # noqa
+            headers={"Authorization": "Bearer testing_token"},
+        ).mock(
+            return_value=Response(
+                200,
+                json={
+                    "state": {
+                        "life_cycle_state": "SKIPPED",
+                        "state_message": "testing",
+                    },
+                    "tasks": [{"run_id": 11223344, "task_key": "prefect-task"}],
+                },
+            )
+        )
+
+        match = re.escape(  # escape to handle the parentheses
+            "Databricks Jobs Runs Submit ID 11223344 was skipped: testing."
+        )
+        with pytest.raises(DatabricksJobSkipped, match=match):
             await jobs_runs_submit_by_id_and_wait_for_completion(
                 databricks_credentials=databricks_credentials,
-                run_name="prefect-job",
-                tasks=[
-                    {
-                        "notebook_task": {
-                            "notebook_path": "path",
-                            "base_parameters": {"param": "a"},
-                        },
-                        "task_key": "key",
-                    }
-                ],
+                job_id=11223344,
             )
-        with pytest.raises(DatabricksJobInternalError, match=match):
+
+    @pytest.mark.respx(assert_all_called=False)
+    async def test_run_now_timeout_error(
+        self, common_mocks, run_now_mocks, respx_mock, databricks_credentials
+    ):
+        respx_mock.post(
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.1/jobs/run-now?job_id=11223344",  # noqa
+            headers={"Authorization": "Bearer testing_token"},
+        ).mock(
+            return_value=Response(
+                200, json={"run_id": 11223344, "number_in_job": 11223344}
+            )
+        )
+        respx_mock.get(
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=11223344",  # noqa
+            headers={"Authorization": "Bearer testing_token"},
+        ).mock(
+            return_value=Response(
+                200,
+                json={
+                    "state": {
+                        "life_cycle_state": "nothing",
+                        "state_message": "",
+                        "result_state": "abc",
+                    },
+                    "tasks": [{"run_id": 11223344, "task_key": "prefect-task"}],
+                },
+            )
+        )
+
+        with pytest.raises(
+            DatabricksJobRunTimedOut, match="Max wait time of 0 seconds"
+        ):
             await jobs_runs_submit_by_id_and_wait_for_completion(
-                databricks_credentials=databricks_credentials, job_id="11223344"
+                databricks_credentials=databricks_credentials,
+                job_id=11223344,
+                max_wait_seconds=0,
             )

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -113,7 +113,7 @@ class TestJobsRunsSubmitAndWaitForCompletion:
     @pytest.mark.respx(assert_all_called=True)
     async def test_run_success(self, common_mocks, respx_mock, databricks_credentials):
         respx_mock.get(
-            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.1/jobs/runs/get?run_id=36108",  # noqa
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=36108",  # noqa
             headers={"Authorization": "Bearer testing_token"},
         ).mock(
             return_value=Response(
@@ -130,7 +130,7 @@ class TestJobsRunsSubmitAndWaitForCompletion:
         )
 
         respx_mock.get(
-            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.1/jobs/runs/get-output",  # noqa
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get-output",  # noqa
             headers={"Authorization": "Bearer testing_token"},
         ).mock(return_value=Response(200, json={"notebook_output": {"cell": "output"}}))
 
@@ -154,12 +154,12 @@ class TestJobsRunsSubmitAndWaitForCompletion:
         self, common_mocks, respx_mock, databricks_credentials
     ):
         respx_mock.get(
-            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.1/jobs/runs/get?run_id=36108",  # noqa
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=36108",  # noqa
             headers={"Authorization": "Bearer testing_token"},
         ).mock(side_effect=successful_job_path)
 
         respx_mock.get(
-            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.1/jobs/runs/get-output",  # noqa
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get-output",  # noqa
             headers={"Authorization": "Bearer testing_token"},
         ).mock(return_value=Response(200, json={"metadata": {"cell": "output"}}))
 

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -42,7 +42,7 @@ def run_now_mocks(respx_mock):
 @pytest.fixture
 def common_mocks(respx_mock):
     respx_mock.post(
-        "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/submit",
+        "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.1/jobs/runs/submit",
         headers={"Authorization": "Bearer testing_token"},
     ).mock(return_value=Response(200, json={"run_id": 11223344}))
 

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -123,7 +123,7 @@ class TestJobsRunsSubmitAndWaitForCompletion:
     @pytest.mark.respx(assert_all_called=True)
     async def test_run_success(self, common_mocks, respx_mock, databricks_credentials):
         respx_mock.get(
-            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=11223344",  # noqa
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.1/jobs/runs/get?run_id=11223344",  # noqa
             headers={"Authorization": "Bearer testing_token"},
         ).mock(
             return_value=Response(
@@ -140,7 +140,7 @@ class TestJobsRunsSubmitAndWaitForCompletion:
         )
 
         respx_mock.get(
-            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get-output",  # noqa
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.1/jobs/runs/get-output",  # noqa
             headers={"Authorization": "Bearer testing_token"},
         ).mock(return_value=Response(200, json={"notebook_output": {"cell": "output"}}))
 
@@ -164,12 +164,12 @@ class TestJobsRunsSubmitAndWaitForCompletion:
         self, common_mocks, respx_mock, databricks_credentials
     ):
         respx_mock.get(
-            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=11223344",  # noqa
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.1/jobs/runs/get?run_id=11223344",  # noqa
             headers={"Authorization": "Bearer testing_token"},
         ).mock(side_effect=successful_job_path)
 
         respx_mock.get(
-            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get-output",  # noqa
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.1/jobs/runs/get-output",  # noqa
             headers={"Authorization": "Bearer testing_token"},
         ).mock(return_value=Response(200, json={"metadata": {"cell": "output"}}))
 
@@ -197,7 +197,7 @@ class TestJobsRunsSubmitAndWaitForCompletion:
         self, result_state, common_mocks, respx_mock, databricks_credentials
     ):
         respx_mock.get(
-            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=11223344",  # noqa
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.1/jobs/runs/get?run_id=11223344",  # noqa
             headers={"Authorization": "Bearer testing_token"},
         ).mock(
             return_value=Response(
@@ -235,7 +235,7 @@ class TestJobsRunsSubmitAndWaitForCompletion:
     @pytest.mark.respx(assert_all_called=True)
     async def test_run_skipped(self, common_mocks, respx_mock, databricks_credentials):
         respx_mock.get(
-            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=11223344",  # noqa
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.1/jobs/runs/get?run_id=11223344",  # noqa
             headers={"Authorization": "Bearer testing_token"},
         ).mock(
             return_value=Response(
@@ -274,7 +274,7 @@ class TestJobsRunsSubmitAndWaitForCompletion:
         self, common_mocks, respx_mock, databricks_credentials
     ):
         respx_mock.get(
-            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=11223344",  # noqa
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.1/jobs/runs/get?run_id=11223344",  # noqa
             headers={"Authorization": "Bearer testing_token"},
         ).mock(
             return_value=Response(
@@ -313,7 +313,7 @@ class TestJobsRunsSubmitAndWaitForCompletion:
         self, common_mocks, respx_mock, databricks_credentials
     ):
         respx_mock.get(
-            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=11223344",  # noqa
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.1/jobs/runs/get?run_id=11223344",  # noqa
             headers={"Authorization": "Bearer testing_token"},
         ).mock(
             return_value=Response(
@@ -352,7 +352,7 @@ class TestJobsRunsSubmitAndWaitForCompletion:
         self, common_mocks, respx_mock, databricks_credentials
     ):
         respx_mock.get(
-            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=11223344",  # noqa
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.1/jobs/runs/get?run_id=11223344",  # noqa
             headers={"Authorization": "Bearer testing_token"},
         ).mock(
             return_value=Response(
@@ -369,7 +369,7 @@ class TestJobsRunsSubmitAndWaitForCompletion:
         )
 
         respx_mock.get(
-            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get-output",  # noqa
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.1/jobs/runs/get-output",  # noqa
             headers={"Authorization": "Bearer testing_token"},
         ).mock(return_value=Response(200, json={"notebook_output": {"cell": "output"}}))
 
@@ -402,7 +402,7 @@ class TestJobsRunsIdSubmitAndWaitForCompletion:
             )
         )
         respx_mock.get(
-            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=11223344",  # noqa
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.1/jobs/runs/get?run_id=11223344",  # noqa
             headers={"Authorization": "Bearer testing_token"},
         ).mock(
             return_value=Response(
@@ -418,7 +418,7 @@ class TestJobsRunsIdSubmitAndWaitForCompletion:
             )
         )
         respx_mock.get(
-            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get-output",  # noqa
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.1/jobs/runs/get-output",  # noqa
             headers={"Authorization": "Bearer testing_token"},
         ).mock(return_value=Response(200, json={"notebook_output": {"cell": "output"}}))
 
@@ -446,7 +446,7 @@ class TestJobsRunsIdSubmitAndWaitForCompletion:
             )
         )
         respx_mock.get(
-            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=11223344",  # noqa
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.1/jobs/runs/get?run_id=11223344",  # noqa
             headers={"Authorization": "Bearer testing_token"},
         ).mock(
             return_value=Response(
@@ -484,7 +484,7 @@ class TestJobsRunsIdSubmitAndWaitForCompletion:
             )
         )
         respx_mock.get(
-            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=11223344",  # noqa
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.1/jobs/runs/get?run_id=11223344",  # noqa
             headers={"Authorization": "Bearer testing_token"},
         ).mock(
             return_value=Response(
@@ -521,7 +521,7 @@ class TestJobsRunsIdSubmitAndWaitForCompletion:
             )
         )
         respx_mock.get(
-            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.0/jobs/runs/get?run_id=11223344",  # noqa
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.1/jobs/runs/get?run_id=11223344",  # noqa
             headers={"Authorization": "Bearer testing_token"},
         ).mock(
             return_value=Response(

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -404,17 +404,7 @@ class TestJobsRunsIdSubmitAndWaitForCompletion:
         ).mock(return_value=Response(200, json={"notebook_output": {"cell": "output"}}))
 
         result = await jobs_runs_submit_by_id_and_wait_for_completion(
-            databricks_credentials=databricks_credentials,
-            run_name="prefect-job",
-            tasks=[
-                {
-                    "notebook_task": {
-                        "notebook_path": "path",
-                        "base_parameters": {"param": "a"},
-                    },
-                    "task_key": "key",
-                }
-            ],
+            databricks_credentials=databricks_credentials, job_id="prefect-job"
         )
         assert result == {"prefect-task": {"cell": "output"}}
 


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes [#63 ](https://github.com/PrefectHQ/prefect-databricks/issues/63)

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->
```
@flow(
    name="Submit existing job runs and wait for completion",
    description=(
        "Triggers a Databricks jobs runs and waits for the "
        "triggered runs to complete."
    ),
)
async def jobs_runs_submit_by_id_and_wait_for_completion(
    databricks_credentials: DatabricksCredentials,
    job_id: Optional[int] = None,
    idempotency_token: Optional[str] = None,
    jar_params: Optional[List[str]] = None,
    max_wait_seconds: int = 900,
    poll_frequency_seconds: int = 10,
    notebook_params: Optional[Dict] = None,
    python_params: Optional[List[str]] = None,
    spark_submit_params: Optional[List[str]] = None,
    python_named_params: Optional[Dict] = None,
    pipeline_params: Optional[str] = None,
    sql_params: Optional[Dict] = None,
    dbt_commands: Optional[List] = None,
    **jobs_runs_submit_kwargs: Dict[str, Any],
) -> Dict:
    logger = get_run_logger()

    # submit the jobs runs

    jobs_runs_future = await jobs_run_now.submit(
        databricks_credentials=databricks_credentials,
        job_id=job_id,
        idempotency_token=idempotency_token,
        jar_params=jar_params,
        notebook_params=notebook_params,
        python_params=python_params,
        spark_submit_params=spark_submit_params,
        python_named_params=python_named_params,
        pipeline_params=pipeline_params,
        sql_params=sql_params,
        dbt_commands=dbt_commands,
        **jobs_runs_submit_kwargs,
    )

    jobs_runs = await jobs_runs_future.result()
    jobs_runs_id = jobs_runs["run_id"]

    # wait for all the jobs runs to complete in a separate flow
    # for a cleaner radar interface
    jobs_runs_state, jobs_runs_metadata = await jobs_runs_wait_for_completion(
        multi_task_jobs_runs_id=jobs_runs_id,
        databricks_credentials=databricks_credentials,
        max_wait_seconds=max_wait_seconds,
        poll_frequency_seconds=poll_frequency_seconds,
    )

    # fetch the state results
    jobs_runs_life_cycle_state = jobs_runs_state["life_cycle_state"]
    jobs_runs_state_message = jobs_runs_state["state_message"]

    # return results or raise error
    if jobs_runs_life_cycle_state == RunLifeCycleState.terminated.value:
        jobs_runs_result_state = jobs_runs_state.get("result_state", None)
        if jobs_runs_result_state == RunResultState.success.value:
            task_notebook_outputs = {}
            # for task in jobs_runs_metadata["tasks"]:
            # task_key = task["task_key"]
            task_run_id = jobs_runs_metadata["run_id"]
            task_run_output_future = await jobs_runs_get_output.submit(
                run_id=task_run_id,
                databricks_credentials=databricks_credentials,
            )
            task_run_output = await task_run_output_future.result()
            task_run_notebook_output = task_run_output.get("notebook_output", {})
            logger.info(
                "Databricks Jobs Runs Submit (%s ID %s) completed successfully!", job_id
            )
            return task_notebook_outputs
        else:
            raise DatabricksJobTerminated(
                f"Databricks Jobs Runs Submit ID {job_id}"
                f"terminated with result state, {jobs_runs_result_state}: "
                f"{jobs_runs_state_message}"
            )
    elif jobs_runs_life_cycle_state == RunLifeCycleState.skipped.value:
        raise DatabricksJobSkipped(
            f"Databricks Jobs Runs Submit ID "
            f"{job_id} was skipped: {jobs_runs_state_message}.",
        )
    elif jobs_runs_life_cycle_state == RunLifeCycleState.internalerror.value:
        raise DatabricksJobInternalError(
            f"Databricks Jobs Runs Submit ID "
            f"{job_id} "
            f"encountered an internal error: {jobs_runs_state_message}.",
        )
```

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-databricks/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-databricks/blob/main/CHANGELOG.md)
