### PR TITLE
Adding runtime engine

### DIFF
--- a/prefect_databricks/models/jobs.py
+++ b/prefect_databricks/models/jobs.py
@@ -2472,7 +2472,7 @@ class NewCluster(BaseModel):
             "unspecified, the runtime engine is inferred from spark_version. "
             "see https://docs.databricks.com/api-explorer/workspace/jobs/create "
             " for more details"
-        )
+        ),
     )
     ssh_public_keys: Optional[List[str]] = Field(
         None,

--- a/prefect_databricks/models/jobs.py
+++ b/prefect_databricks/models/jobs.py
@@ -2465,7 +2465,7 @@ class NewCluster(BaseModel):
             " API call."
         ),
     )
-    runtime_engine: Optional[RuntimeEngine] = Field (
+    runtime_engine: Optional[RuntimeEngine] = Field(
         None,
         description=(
             "Decides which runtime engine to be use, e.g. Standard vs. Photon. If "
@@ -2474,7 +2474,6 @@ class NewCluster(BaseModel):
             " for more details"
         )
     )
-
     ssh_public_keys: Optional[List[str]] = Field(
         None,
         description=(

--- a/prefect_databricks/models/jobs.py
+++ b/prefect_databricks/models/jobs.py
@@ -808,7 +808,7 @@ class ListOrder(str, Enum):
 
 class RuntimeEngine(str, Enum):
     """
-    Permission to view the settings of the job.
+    Decides which runtime engine to be use, e.g. Standard vs. Photon. If unspecified, the runtime engine is inferred from spark_version.
     """
 
     standard = "STANDARD"

--- a/prefect_databricks/models/jobs.py
+++ b/prefect_databricks/models/jobs.py
@@ -806,6 +806,15 @@ class ListOrder(str, Enum):
     asc = "ASC"
 
 
+class RuntimeEngine(str, Enum):
+    """
+    Permission to view the settings of the job.
+    """
+
+    standard = "STANDARD"
+    photon = "PHOTON"
+
+
 class LogSyncStatus(BaseModel):
     """
     See source code for the fields' description.
@@ -2455,7 +2464,17 @@ class NewCluster(BaseModel):
             " versions](https://docs.databricks.com/dev-tools/api/latest/clusters.html#runtime-versions)"
             " API call."
         ),
-    )
+    ),
+    runtime_engine: Optional[RuntimeEngine] = Field (
+        None,
+        description=(
+            "Decides which runtime engine to be use, e.g. Standard vs. Photon. If "
+            "unspecified, the runtime engine is inferred from spark_version. "
+            "see https://docs.databricks.com/api-explorer/workspace/jobs/create "
+            " for more details"
+        )
+    ) ,
+
     ssh_public_keys: Optional[List[str]] = Field(
         None,
         description=(

--- a/prefect_databricks/models/jobs.py
+++ b/prefect_databricks/models/jobs.py
@@ -2464,7 +2464,7 @@ class NewCluster(BaseModel):
             " versions](https://docs.databricks.com/dev-tools/api/latest/clusters.html#runtime-versions)"
             " API call."
         ),
-    ),
+    )
     runtime_engine: Optional[RuntimeEngine] = Field (
         None,
         description=(
@@ -2473,7 +2473,7 @@ class NewCluster(BaseModel):
             "see https://docs.databricks.com/api-explorer/workspace/jobs/create "
             " for more details"
         )
-    ) ,
+    )
 
     ssh_public_keys: Optional[List[str]] = Field(
         None,


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes #55 

### Example

The 2.1 jobs API 2.1 now support also a runtime_engine, that can be passed to enable Photon runtime. This PR adds this optional field to the NewCluster model. 

PS: how about instead depending on Databricks Python SDK?

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-databricks/issues/new/choose) first.
- [ ] Includes tests or only affects documentation.
- [ ] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [ ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-databricks/blob/main/CHANGELOG.md)
